### PR TITLE
Fix claim redelegate v2

### DIFF
--- a/src/components/ValidatorSelectDialog/ValidatorSelectDialog.tsx
+++ b/src/components/ValidatorSelectDialog/ValidatorSelectDialog.tsx
@@ -194,6 +194,7 @@ export const ValidatorSelectDialog: React.FC<ValidatorSelectDialogProps> = ({
           balance: v.balance,
         })),
         validatorRewards,
+        isSimulation 
       );
 
       if (isSimulation) return claimResult;

--- a/src/components/ValidatorSelectDialog/ValidatorSelectDialog.tsx
+++ b/src/components/ValidatorSelectDialog/ValidatorSelectDialog.tsx
@@ -278,8 +278,8 @@ export const ValidatorSelectDialog: React.FC<ValidatorSelectDialogProps> = ({
   };
 
   useEffect(() => {
-    if (slideTrayIsOpen) updateFee();
-  }, [slideTrayIsOpen, selectedValidators, isClaimDialog]);
+    if (slideTrayIsOpen && !isLoading) updateFee();
+  }, [slideTrayIsOpen, selectedValidators, isClaimDialog, isLoading]);
 
   useEffect(() => {
     if (shouldRefreshData && transactionSuccess.success) {


### PR DESCRIPTION
Updated version of the original fix: 
Prevents RPC spam 
Passes simulate properly
Allows for batched transactions to avoid the account nonce unreliability issue (does not support more than 20tx yet, that is future TODO)
